### PR TITLE
Fix order of assert parameters

### DIFF
--- a/src/test/java/de/rub/nds/praktikum/protocol/AlertLayerTest.java
+++ b/src/test/java/de/rub/nds/praktikum/protocol/AlertLayerTest.java
@@ -34,19 +34,19 @@ public class AlertLayerTest {
     @Category(de.rub.nds.praktikum.Aufgabe1.class)
     public void testSendAlert() throws Exception {
         layer.sendAlert(AlertLevel.WARNING, AlertDescription.BAD_RECORD_MAC);
-        assertArrayEquals("Alert is not warning, bad record mac",outputStream.toByteArray(), Util.hexStringToByteArray("15030300020114"));
+        assertArrayEquals("Alert is not warning, bad record mac", Util.hexStringToByteArray("15030300020114"), outputStream.toByteArray());
         layer.sendAlert(AlertLevel.FATAL, AlertDescription.BAD_RECORD_MAC);
-        assertArrayEquals("Alert is not fatal, bad record mac",outputStream.toByteArray(), Util.hexStringToByteArray("1503030002011415030300020214"));
+        assertArrayEquals("Alert is not fatal, bad record mac", Util.hexStringToByteArray("1503030002011415030300020214"), outputStream.toByteArray());
     }
 
     @Test
     @Category(de.rub.nds.praktikum.Aufgabe2.class)
     public void testSendAlertTask2() throws Exception {
         layer.sendAlert(AlertLevel.WARNING, AlertDescription.BAD_RECORD_MAC);
-        assertArrayEquals("Alert is not warning, bad record mac",outputStream.toByteArray(), Util.hexStringToByteArray("15030300020114"));
+        assertArrayEquals("Alert is not warning, bad record mac", Util.hexStringToByteArray("15030300020114"), outputStream.toByteArray());
         assertNotEquals("Warning alerts should be fine", TlsState.ERROR, context.getTlsState());
         layer.sendAlert(AlertLevel.FATAL, AlertDescription.BAD_RECORD_MAC);
-        assertArrayEquals("Alert is not fatal, bad record mac",outputStream.toByteArray(), Util.hexStringToByteArray("1503030002011415030300020214"));
+        assertArrayEquals("Alert is not fatal, bad record mac", Util.hexStringToByteArray("1503030002011415030300020214"), outputStream.toByteArray());
         assertEquals("Fatal alerts should move us to the error state", TlsState.ERROR, context.getTlsState());
     }
 

--- a/src/test/java/de/rub/nds/praktikum/protocol/ApplicationLayerTest.java
+++ b/src/test/java/de/rub/nds/praktikum/protocol/ApplicationLayerTest.java
@@ -35,7 +35,7 @@ public class ApplicationLayerTest {
     @Test
     public void testSendData() throws Exception {
         layer.sendData(Util.hexStringToByteArray("AABBCC"));
-        assertArrayEquals("Invalid data send",outputStream.toByteArray(), Util.hexStringToByteArray("1703030003AABBCC"));
+        assertArrayEquals("Invalid data send", Util.hexStringToByteArray("1703030003AABBCC"), outputStream.toByteArray());
     }
 
     @Test

--- a/src/test/java/de/rub/nds/praktikum/protocol/HandshakeLayerTest.java
+++ b/src/test/java/de/rub/nds/praktikum/protocol/HandshakeLayerTest.java
@@ -280,8 +280,8 @@ public class HandshakeLayerTest {
                 return null;
             }
         };
-        assertNotEquals("Client finshed key must be set",null, context.getClientFinishedKey());
-        assertNotEquals("Server finshed key must be set",null, context.getServerFinishedKey());
+        assertNotNull("Client finshed key must be set", context.getClientFinishedKey());
+        assertNotNull("Server finshed key must be set", context.getServerFinishedKey());
         assertArrayEquals("The Digest does not equal - did you foret to update it?", Util.hexStringToByteArray("9ab9f32be1080f7f1ba315137e4f38c25e216dc33185b386d92c234a8c9a441b"), context.getDigest());
         tempParser.parse();
     }

--- a/src/test/java/de/rub/nds/praktikum/protocol/RecordLayerTest.java
+++ b/src/test/java/de/rub/nds/praktikum/protocol/RecordLayerTest.java
@@ -145,8 +145,8 @@ public class RecordLayerTest {
         assertEquals("The number of records is invalid",1, receivedRecords.size());
         Record testRecord = receivedRecords.get(0);
         assertEquals("Type is not from the record",0x33, testRecord.getType());
-        assertArrayEquals("Version is not from the record",testRecord.getVersion(), Util.hexStringToByteArray("FFFF"));
-        assertArrayEquals("Data is not from the record",testRecord.getData(), Util.hexStringToByteArray("CC"));
+        assertArrayEquals("Version is not from the record", Util.hexStringToByteArray("FFFF"), testRecord.getVersion());
+        assertArrayEquals("Data is not from the record", Util.hexStringToByteArray("CC"), testRecord.getData());
         inputStream = new ByteArrayInputStream(Util.hexStringToByteArray("33FFFF0001CC33FFFF0001CC33FFFF0001CC33FFFF0001CC33FFFF0001CC33FFFF0001CC33FFFF0001CC33FFFF0001CC"));
         recordLayer = new RecordLayer(outputStream, inputStream, context, 0);
         receivedRecords = recordLayer.receiveData();

--- a/src/test/java/de/rub/nds/praktikum/records/RecordSerializerTest.java
+++ b/src/test/java/de/rub/nds/praktikum/records/RecordSerializerTest.java
@@ -19,7 +19,7 @@ public class RecordSerializerTest {
         Record record = new Record((byte) 3, new byte[]{0x03, 0x03}, new byte[]{01, 02, 03, 04});
         RecordSerializer serializer = new RecordSerializer(record);
         byte[] serializeBytes = serializer.serialize();
-        assertArrayEquals("Record serialize failed",serializeBytes, Util.hexStringToByteArray("030303000401020304"));
+        assertArrayEquals("Record serialize failed", Util.hexStringToByteArray("030303000401020304"), serializeBytes);
     }
 
 }


### PR DESCRIPTION
The order of assert parameters was wrong in some tests, which lead to confusing messages on test fail.